### PR TITLE
Fix comment typo in fetch_cdm

### DIFF
--- a/ml/fetch_cdm.py
+++ b/ml/fetch_cdm.py
@@ -4,7 +4,7 @@ and save them as Parquet for ML work.
 
 Usage:
     $ python fetch_cdm.py          # last 90 days → raw/cdm_<date>.parquet
-    $ DAYS=365 python fetch_cdm.py # customise look-back window
+    $ DAYS=365 python fetch_cdm.py # customize look-back window
 """
 import os
 import pandas as pd


### PR DESCRIPTION
## Summary
- correct `customize` spelling in usage example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687558caba90832d97507b119d4ac3cd