### PR TITLE
Load Cesium token from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ A full-stack tool for visualizing and predicting satellite collision risk.
 - ML model predicts collision risk using miss distance, time to closest approach, and relative speed.
 - Flask backend serves TLE data and risk predictions via REST API.
 - React frontend with CesiumJS displays satellites and debris on a 3D globe, color-coded by risk.
+
+## Configuration
+
+Set the Cesium Ion access token via the `VITE_CESIUM_ION_TOKEN` environment
+variable when running the frontend. For example:
+
+```bash
+VITE_CESIUM_ION_TOKEN=your_token_here npm run dev
+```
+
+The token is required for loading Cesium assets.

--- a/spacetrack/src/App.jsx
+++ b/spacetrack/src/App.jsx
@@ -11,7 +11,10 @@ import * as satellite from "satellite.js";
 import axios from "axios";
 import RiskInfoPanel from "./components/RiskInfoPanel";
 import * as Cesium from "cesium";
-Cesium.Ion.defaultAccessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI5ZTQ5NDNiNS1iNGVlLTRiYzgtOWJlYi0wOTdlYTNmZTVmYWMiLCJpZCI6MzE4ODEzLCJpYXQiOjE3NTE3MzU1MDh9.5rwp27kvKaXjgZvzZW68A14aG4coUC6E1scwvNXmzeQ";
+// Read Cesium Ion access token from environment. When running via Vite,
+// environment variables exposed to the client must be prefixed with `VITE_`.
+Cesium.Ion.defaultAccessToken =
+  import.meta.env.VITE_CESIUM_ION_TOKEN || "";
 
 
 


### PR DESCRIPTION
## Summary
- fetch Cesium Ion token from `import.meta.env.VITE_CESIUM_ION_TOKEN`
- document the new env var in the README

## Testing
- `npm run lint` *(fails: Cannot find package `globals`)*

------
https://chatgpt.com/codex/tasks/task_e_68755a1f98c8832d90a0cd9f9e08cb10