### PR TITLE
Update Cesium token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,17 @@ A full-stack tool for visualizing and predicting satellite collision risk.
 - ML model predicts collision risk using miss distance, time to closest approach, and relative speed.
 - Flask backend serves TLE data and risk predictions via REST API.
 - React frontend with CesiumJS displays satellites and debris on a 3D globe, color-coded by risk.
+
+## Setup
+
+The Cesium viewer requires an [Ion access token](https://cesium.com/ion/) which
+should be provided through Vite's environment system. Inside the `spacetrack`
+folder create a `.env` file and add your token:
+
+```env
+VITE_CESIUM_TOKEN=YOUR_TOKEN_HERE
+```
+
+`vite.config.js` loads this variable automatically so the React code can access
+it via `import.meta.env.VITE_CESIUM_TOKEN`.
+

--- a/spacetrack/src/App.jsx
+++ b/spacetrack/src/App.jsx
@@ -11,7 +11,8 @@ import * as satellite from "satellite.js";
 import axios from "axios";
 import RiskInfoPanel from "./components/RiskInfoPanel";
 import * as Cesium from "cesium";
-Cesium.Ion.defaultAccessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI5ZTQ5NDNiNS1iNGVlLTRiYzgtOWJlYi0wOTdlYTNmZTVmYWMiLCJpZCI6MzE4ODEzLCJpYXQiOjE3NTE3MzU1MDh9.5rwp27kvKaXjgZvzZW68A14aG4coUC6E1scwvNXmzeQ";
+// Cesium Ion token comes from the VITE_CESIUM_TOKEN entry in .env
+Cesium.Ion.defaultAccessToken = import.meta.env.VITE_CESIUM_TOKEN;
 
 
 

--- a/spacetrack/vite.config.js
+++ b/spacetrack/vite.config.js
@@ -1,4 +1,5 @@
 // spacetrack/vite.config.js
+// Environment variables (like VITE_CESIUM_TOKEN) are loaded from `.env` by Vite
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";


### PR DESCRIPTION
## Summary
- read Cesium Ion token from `import.meta.env.VITE_CESIUM_TOKEN`
- note the required `.env` variable and mention it in `vite.config.js`

## Testing
- `npm --prefix spacetrack run build` *(fails: vite not found)*
- `npm --prefix spacetrack run lint` *(fails: cannot find package globals)*

------
https://chatgpt.com/codex/tasks/task_e_6875706b4824832da64827e4fc92614f