### PR TITLE
Add ML docs and minimal unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ A full-stack tool for visualizing and predicting satellite collision risk.
 - ML model predicts collision risk using miss distance, time to closest approach, and relative speed.
 - Flask backend serves TLE data and risk predictions via REST API.
 - React frontend with CesiumJS displays satellites and debris on a 3D globe, color-coded by risk.
+
+## Machine Learning
+
+The `ml/` directory contains scripts for downloading CDMs, building features and
+training the risk model. See [ml/README.md](ml/README.md) for details on running
+`fetch_cdm.py`, `make_features.py` and `train.py`.

--- a/ml/README.md
+++ b/ml/README.md
@@ -1,0 +1,45 @@
+# Machine Learning Workflow
+
+This folder contains simple scripts used to train the collision–risk model.
+
+## Setup
+
+Create a Python environment with the dependencies listed in `requirements.txt` (or
+use `environment.yml` with conda).
+
+```bash
+pip install -r requirements.txt
+# or
+conda env create -f environment.yml
+```
+
+## Download the CDM data
+
+`fetch_cdm.py` downloads public Conjunction Data Messages from Space-Track and
+saves them under `raw/` as a parquet file. Export your Space‑Track credentials
+and run the script:
+
+```bash
+export SPACE_TRACK_USER=<username>
+export SPACE_TRACK_PASS=<password>
+python fetch_cdm.py            # downloads last 90 days
+DAYS=365 python fetch_cdm.py   # customise look-back window
+```
+
+## Generate training features
+
+`make_features.py` transforms the raw CDM file into a features table. It expects
+TLE data in memory and writes `proc/features.parquet`.
+
+```bash
+python make_features.py
+```
+
+## Train the model
+
+`train.py` reads `proc/features.parquet` and outputs the trained model
+`model_risk.pkl`.
+
+```bash
+python train.py
+```

--- a/tests/test_ml_model.py
+++ b/tests/test_ml_model.py
@@ -1,0 +1,56 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import importlib
+import types
+
+class FakeArray:
+    def __init__(self, data):
+        self.data = data
+    @property
+    def shape(self):
+        if not self.data:
+            return (0, 0)
+        first = self.data[0]
+        return (len(self.data), len(first) if isinstance(first, list) else 1)
+    def __len__(self):
+        return len(self.data)
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return FakeArray(self.data[idx])
+        elif isinstance(idx, tuple):
+            rows, cols = idx
+            row_data = self.data[rows] if not isinstance(rows, slice) else self.data[rows]
+            if not isinstance(rows, slice):
+                row_data = [row_data]
+            if isinstance(cols, slice):
+                result = [r[cols] for r in row_data]
+            else:
+                result = [r[cols] for r in row_data]
+                return FakeArray(result)
+            return FakeArray(result)
+        else:
+            return self.data[idx]
+    def tolist(self):
+        return self.data
+
+class DummyDF:
+    def __getitem__(self, item):
+        return self
+    def to_numpy(self, dtype=float):
+        return FakeArray([[0,0,0,0,0] for _ in range(10)])
+
+class DummyModel:
+    def predict_proba(self, X):
+        return FakeArray([[0.0, 1.0] for _ in range(len(X))])
+
+def test_predict_risks_monkeypatched():
+    pd_stub = types.ModuleType('pandas')
+    pd_stub.read_parquet = lambda path: DummyDF()
+    joblib_stub = types.ModuleType('joblib')
+    joblib_stub.load = lambda path: DummyModel()
+    sys.modules['pandas'] = pd_stub
+    sys.modules['joblib'] = joblib_stub
+
+    ml_model = importlib.import_module('backend.ml_model')
+    result = ml_model.predict_risks([{'line1': 'foo', 'line2': 'bar'}])
+    assert result == [1.0]


### PR DESCRIPTION
## Summary
- document the ML workflow in `ml/README.md`
- reference ML instructions from the main README
- add a pytest unit test for `predict_risks`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68757067c9a0832d96e69fc8a616e898